### PR TITLE
Fix compatibility issues in Django 1.8.

### DIFF
--- a/sundial/fields.py
+++ b/sundial/fields.py
@@ -19,7 +19,7 @@ class TimezoneField(with_metaclass(TimezoneFieldBase, models.CharField)):
         kwargs.setdefault('max_length', self.default_max_length)
         super(TimezoneField, self).__init__(*args, **kwargs)
 
-    def from_db_value(self, value, connection, context):
+    def from_db_value(self, value, expression, connection, context):
         if value:
             value = coerce_timezone(value)
         return value


### PR DESCRIPTION
Failed to test in Django 1.8. `from_db_value()` have to take 5 arguments.

```
======================================================================
ERROR: test_default (tests.test_fields.tests.TimezoneFieldTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kosei/Repos/django-sundial/tests/test_fields/tests.py", line 33, in test_default
    obj = TimezoneModel.objects.get()
  File "/Users/kosei/.virtualenvs/zqumo/lib/python2.7/site-packages/django/db/models/manager.py", line 127, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/kosei/.virtualenvs/zqumo/lib/python2.7/site-packages/django/db/models/query.py", line 328, in get
    num = len(clone)
  File "/Users/kosei/.virtualenvs/zqumo/lib/python2.7/site-packages/django/db/models/query.py", line 144, in __len__
    self._fetch_all()
  File "/Users/kosei/.virtualenvs/zqumo/lib/python2.7/site-packages/django/db/models/query.py", line 965, in _fetch_all
    self._result_cache = list(self.iterator())
  File "/Users/kosei/.virtualenvs/zqumo/lib/python2.7/site-packages/django/db/models/query.py", line 254, in iterator
    for row in compiler.results_iter(results):
  File "/Users/kosei/.virtualenvs/zqumo/lib/python2.7/site-packages/django/db/models/sql/compiler.py", line 789, in results_iter
    row = self.apply_converters(row, converters)
  File "/Users/kosei/.virtualenvs/zqumo/lib/python2.7/site-packages/django/db/models/sql/compiler.py", line 773, in apply_converters
    value = converter(value, expression, self.connection, self.query.context)
TypeError: from_db_value() takes exactly 4 arguments (5 given)
```
