### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 django-sundial
 ==============
 
-.. image:: https://pypip.in/license/django-sundial/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/l/django-sundial.svg?style=flat
     :target: https://pypi.python.org/pypi/django-sundial/
     :alt: License
 
-.. image:: https://pypip.in/version/django-sundial/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/v/django-sundial.svg?style=flat
     :target: https://pypi.python.org/pypi/django-sundial/
     :alt: Latest Version
 
@@ -17,11 +17,11 @@ django-sundial
     :target: https://coveralls.io/r/charettes/django-sundial?branch=master
     :alt: Coverage Status
 
-.. image:: https://pypip.in/py_versions/django-sundial/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/pyversions/django-sundial.svg?style=flat
     :target: https://pypi.python.org/pypi/django-sundial/
     :alt: Supported Python Versions
 
-.. image:: https://pypip.in/wheel/django-sundial/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/wheel/django-sundial.svg?style=flat
     :target: https://pypi.python.org/pypi/django-sundial/
     :alt: Wheel Status
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-sundial))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-sundial`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.