### PR TITLE
Resolve RemovedInDjango30Warning deprecation warning.

### DIFF
--- a/sundial/fields.py
+++ b/sundial/fields.py
@@ -16,19 +16,17 @@ class TimezoneField(models.CharField):
         kwargs.setdefault('max_length', self.default_max_length)
         super(TimezoneField, self).__init__(*args, **kwargs)
 
-    # 'context' argument was deprecated in Django 2.0
-    # See: https://docs.djangoproject.com/en/2.0/releases/2.0/#features-deprecated-in-2-0
-    if django.VERSION < (2,):
-        # TODO: remove when Django<2 support is dropped.
-        def from_db_value(self, value, expression, connection, context):
-            if value:
-                value = coerce_timezone(value)
-            return value
-    else:
+    if django.VERSION >= (2, 0):
         def from_db_value(self, value, expression, connection):
             if value:
                 value = coerce_timezone(value)
             return value
+    else:
+        def from_db_value(self, value, expression, connection, context):
+            if value:
+                value = coerce_timezone(value)
+            return value
+        
 
     def to_python(self, value):
         value = super(TimezoneField, self).to_python(value)

--- a/sundial/fields.py
+++ b/sundial/fields.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import django
 from django.db import models
 from django.utils.encoding import force_text
 
@@ -15,10 +16,19 @@ class TimezoneField(models.CharField):
         kwargs.setdefault('max_length', self.default_max_length)
         super(TimezoneField, self).__init__(*args, **kwargs)
 
-    def from_db_value(self, value, expression, connection, context):
-        if value:
-            value = coerce_timezone(value)
-        return value
+    # 'context' argument was deprecated in Django 2.0
+    # See: https://docs.djangoproject.com/en/2.0/releases/2.0/#features-deprecated-in-2-0
+    if django.VERSION < (2,):
+        # TODO: remove when Django<2 support is dropped.
+        def from_db_value(self, value, expression, connection, context):
+            if value:
+                value = coerce_timezone(value)
+            return value
+    else:
+        def from_db_value(self, value, expression, connection):
+            if value:
+                value = coerce_timezone(value)
+            return value
 
     def to_python(self, value):
         value = super(TimezoneField, self).to_python(value)

--- a/sundial/fields.py
+++ b/sundial/fields.py
@@ -26,7 +26,6 @@ class TimezoneField(models.CharField):
             if value:
                 value = coerce_timezone(value)
             return value
-        
 
     def to_python(self, value):
         value = super(TimezoneField, self).to_python(value)


### PR DESCRIPTION
The 'context' argument was [deprecated in Django 2.0](https://docs.djangoproject.com/en/2.0/releases/2.0/#features-deprecated-in-2-0).

This PR adds a conditional method declaration, based on the installed Django version, to resolve the warning.

An alternative approach would be to just change the method signature to ``def from_db_value(self, value, *args, **kwargs):`` - but this version is a little more explicit and makes it clear what should be done when Django<2 support is dropped.